### PR TITLE
Fix dynamic page params and update tests

### DIFF
--- a/src/app/post/[id]/edit/page.tsx
+++ b/src/app/post/[id]/edit/page.tsx
@@ -8,9 +8,9 @@ import { getPost } from "../../actions"
 export default async function PostEditPage({
   params,
 }: {
-  params: Promise<{ id: string }>
+  params: { id: string }
 }) {
-  const { id } = await params
+  const { id } = params
 
   // Check if user is authenticated
   const authUser = await checkAuth()

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -13,9 +13,9 @@ import { getPost } from "../actions"
 export default async function PostDetailPage({
   params,
 }: {
-  params: Promise<{ id: string }>
+  params: { id: string }
 }) {
-  const { id } = await params
+  const { id } = params
   const post = await getPost(id)
 
   // If post doesn't exist, show 404 page

--- a/src/app/post/actions.test.ts
+++ b/src/app/post/actions.test.ts
@@ -27,12 +27,19 @@ describe("Post Actions", () => {
   describe("getPosts", () => {
     test("fetches posts successfully", async () => {
       const mockPosts = [
-        { id: "1", title: "Test Post", content: "Test content", userId: "1" },
+        {
+          id: "1",
+          title: "Test Post",
+          content: "Test content",
+          userId: "1",
+          likeUsers: [],
+        },
         {
           id: "2",
           title: "Another Post",
           content: "More content",
           userId: "2",
+          likeUsers: [],
         },
       ]
 
@@ -73,6 +80,7 @@ describe("Post Actions", () => {
         title: "Test Post",
         content: "Test content",
         userId: "1",
+        likeUsers: [],
       }
 
       global.fetch = vi.fn().mockResolvedValueOnce({

--- a/src/app/user/[id]/edit/page.tsx
+++ b/src/app/user/[id]/edit/page.tsx
@@ -7,9 +7,9 @@ import { UserForm } from "@/components/user/user-form"
 export default async function UserEditPage({
   params,
 }: {
-  params: Promise<{ id: string }>
+  params: { id: string }
 }) {
-  const { id } = await params
+  const { id } = params
 
   // Check if user is authenticated
   const authUser = await checkAuth()

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -11,9 +11,9 @@ import { getUser } from "../actions"
 export default async function UserDetailPage({
   params,
 }: {
-  params: Promise<{ id: string }>
+  params: { id: string }
 }) {
-  const { id } = await params
+  const { id } = params
   const user = await getUser(id)
   const authUser = await checkAuth()
 


### PR DESCRIPTION
## Summary
- include `likeUsers` in mock data for post action tests
- accept synchronous params in dynamic pages

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841132afa78832fa1d860f309ad87a0