### PR TITLE
fix: use proper date comparison in PostCard edited indicator

### DIFF
--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -88,7 +88,8 @@ export function PostCard({
             </span>
 
             {/* Updated indicator */}
-            {post.updatedAt !== post.createdAt && (
+            {new Date(post.updatedAt).getTime() !==
+              new Date(post.createdAt).getTime() && (
               <span className="text-xs">Edited</span>
             )}
           </div>


### PR DESCRIPTION
- Compare date values using getTime() instead of object references
- Ensures correct behavior for both string and Date object inputs
- Prevents false positives when comparing Date objects with same time